### PR TITLE
HOTFIX: Patch the broken link on the button.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -242,7 +242,7 @@
                                 <div class="deck--content deck-one-column--content">
                       <div class="paragraph paragraph--type--text paragraph--view-mode--default">
           
-            <div class="text-formatted field field--name-field-body field--type-text-long field--label-hidden field__item"><div class="button-row-4"><a class="btn btn-lg btn-color-1" data-entity-substitution="canonical" data-entity-type="node" data-entity-uuid="5ee70d59-c2e1-429e-830e-11db249a4793" href="/program" role="button" title="Program &amp; Schedule">View latest DrupalCampNYC website</a></div>
+            <div class="text-formatted field field--name-field-body field--type-text-long field--label-hidden field__item"><div class="button-row-4"><a class="btn btn-lg btn-color-1" data-entity-substitution="canonical" data-entity-type="node" data-entity-uuid="5ee70d59-c2e1-429e-830e-11db249a4793" href="https://2020.drupalcamp.nyc/" role="button" title="Program &amp; Schedule">View latest DrupalCampNYC website</a></div>
 </div>
       
       </div>


### PR DESCRIPTION
"View latest DrupalCampNYC website" button was linked to http://dcnyc2020.hotwebmatter.com/program instead of to https://2020.drupalcamp.nyc/

This PR fixes that issue, and that's all it does. :+1: